### PR TITLE
Update Supermodel.ini for pi-arm

### DIFF
--- a/Config/Supermodel.ini
+++ b/Config/Supermodel.ini
@@ -32,7 +32,7 @@
 [ Global ]
 
 ; Graphics
-New3DEngine = true
+New3DEngine = false
 QuadRendering = false
 WideScreen = false
 Stretch = false
@@ -190,8 +190,8 @@ InputGunLeft2 = "NONE"
 InputGunRight2 = "NONE"
 InputGunUp2 = "NONE"
 InputGunDown2 = "NONE"
-InputGunX2 = "JOY2_XAXIS,MOUSE2_XAXIS"
-InputGunY2 = "JOY2_YAXIS,MOUSE2_YAXIS"
+InputGunX2 = "MOUSE2_XAXIS,JOY2_XAXIS,MOUSE2_XAXIS"
+InputGunY2 = "MOUSE2_XAXIS,JOY2_YAXIS,MOUSE2_YAXIS"
 InputTrigger2 = "JOY2_BUTTON1,MOUSE2_LEFT_BUTTON"
 InputOffscreen2 = "JOY2_BUTTON2,MOUSE2_RIGHT_BUTTON"
 InputAutoTrigger2 = 1
@@ -256,7 +256,6 @@ InputFishingSelect = "KEY_X,JOY1_BUTTON2"
 InputFishingTension = "KEY_T,JOY1_ZAXIS_NEG"
  
  ;Our non input settings...					   
-New3DEngine=0
 
 ; Game specific settings
 ;daytona 2 power edition
@@ -309,19 +308,24 @@ PowerPCFrequency = 40
     [ lemans24 ]
  ;The Lost World (Japan, Revision A)   
     [ lostwsga ];The Lost World (Original Revision)
-PowerPCFrequency = 30	
+PowerPCFrequency = 33	
     [ lostwsgo ]
-PowerPCFrequency = 30
+PowerPCFrequency = 33
 ;Magical Truck Adventure (Japan)    
     [ magtruck ]
 PowerPCFrequency = 40
 ;The Ocean Hunter - Default works fine on pi 
     [ oceanhun ]
+MusicVolume = 200
+SoundVolume = 200
+    [ oceanhuna ]
+MusicVolume = 200
+SoundVolume = 200
 ;Scud Race (Australia, Twin)	
     [ scud ]
 PowerPCFrequency = 35
 MusicVolume = 200
-EmulateDSB = 10
+EmulateDSB = 1
 ;Scud Race (Export, Twin)	
     [ scuda ]
 PowerPCFrequency = 35


### PR DESCRIPTION
A few Supermodel.ini edits for pi-arm users, for your consideration.

- Changed `New3DEngine = true` to `false` and removed the later duplicate `New3DEngine=0` as I'm not convinced it actually did anything. I had noticed some graphical glitching at the start of Star Wars Trilogy's Episode 5 when set to true, that were not present when changed to false. I wasn't aware of the duplicate setting (=0) at the time so it's presence had no effect. Perhaps 1 and 0 are no substitute for true and false in these settings. In any case, having a global setting applied at one point then globally overridden at a later point would be confusing, so applying the setting only once with the intended value is probably better practice.
- Added Player 2 Mouse2 axes to Lost World inputs, the Mouse2 _buttons_ were already applied.
- Changed **lostwsga** and **lostwsgo** `PowerPCFrequency = 30` to `33` (without this edit the game becomes unplayable at the first T-Rex encounter)
- Added **oceanhun** and **oceanhuna** `MusicVolume = 200` and `SoundVolume = 200` (a very quiet game, better but still quiet even with volumes at this max level)
- Changed **scud** `EmulateDSB = 10` to `1` as I'm sure this was a typo, only 1 and 0 are valid values.  Not a game I expect to use, but the `10` value is probably incorrect. The clone **scuda** has this value set to `1` so probably the intended value.
