### PR TITLE
Ignore GLEW error that is not required

### DIFF
--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -239,7 +239,8 @@ static bool CreateGLScreen(const std::string &caption, bool focusWindow, unsigne
 
   // Initialize GLEW, allowing us to use features beyond OpenGL 1.2
   err = glewInit();
-  if (GLEW_OK != err)
+  // Ignore not required GLX error
+  if (GLEW_OK != err && GLEW_ERROR_NO_GLX_DISPLAY != err)
   {
     ErrorLog("OpenGL initialization failed: %s\n", glewGetErrorString(err));
     return FAIL;


### PR DESCRIPTION
In attempting to get this branch working on JelOS/Rocknix (light weight linux distribution designed for retro handhelds), I came across an error from glew when running.

I found that glewInit() was returning GLEW_ERROR_NO_GLX_DISPLAY.  When investigating further I determined that this error was not necessarily an issue and by ignoring it everything ran as intended.

Other emulator platforms I've found do something similar for example here https://github.com/hrydgard/ppsspp/blob/fc58a97024e9f4f6f3476150b797380c17fabf0e/SDL/SDLGLGraphicsContext.cpp#L399

Submitting this PR as a general fix to allow this branch to be more widely usable on lighter weight linux distros.