### PR TITLE
Add device sorting to evdev backend, add environment flag for filtering out non-ABS devices

### DIFF
--- a/Src/Inputs/Linux_evdev.c
+++ b/Src/Inputs/Linux_evdev.c
@@ -40,6 +40,7 @@ typedef struct
 
 static MouseStruct mice[MAX_MICE];
 static unsigned int available_mice = 0;
+static unsigned int absOnly = 0;
 
 
 static int poll_mouse(MouseStruct *mouse, ManyMouseEvent *outevent)
@@ -189,7 +190,7 @@ static int init_mouse(const char *fname, int fd)
         }
     }
 
-    if (!is_mouse || (getenv("SUPERMODEL_GUNSONLY") != NULL && is_mouse && !has_absolutes) )
+    if (!is_mouse || (absOnly && is_mouse && !has_absolutes) )
         return 0;
 
     mouse->min_x = mouse->min_y = mouse->max_x = mouse->max_y = 0;
@@ -258,8 +259,9 @@ static int sort_devices(const void* a, const void* b)
 }
 
 
-static int linux_evdev_init(void)
+static int linux_evdev_init(const int onlyAbs)
 {
+    absOnly = onlyAbs;
     DIR *dirp;
     struct dirent *dent;
     int i;

--- a/Src/Inputs/Linux_evdev.c
+++ b/Src/Inputs/Linux_evdev.c
@@ -212,6 +212,7 @@ static int init_mouse(const char *fname, int fd)
         snprintf(mouse->name, sizeof (mouse->name), "Unknown device");
 
     mouse->fd = fd;
+    /* skipping past "/dev/input/event" so we isolate the number */
     mouse->eventNum = atoi(fname+16);
 
     return 1;
@@ -285,6 +286,7 @@ static int linux_evdev_init(const int onlyAbs)
 
     closedir(dirp);
 
+    /* Sort devices based on eventfile number (from first to most recently registered) */
     if(available_mice)
         qsort(mice, available_mice, sizeof(MouseStruct), sort_devices);
 

--- a/Src/Inputs/Macosx_hidmanager.c
+++ b/Src/Inputs/Macosx_hidmanager.c
@@ -365,7 +365,7 @@ static void macosx_hidmanager_quit(void)
 } /* macosx_hidmanager_quit */
 
 
-static int macosx_hidmanager_init(void)
+static int macosx_hidmanager_init(const int onlyAbs)
 {
     macosx_hidmanager_quit();  /* just in case... */
 

--- a/Src/Inputs/Macosx_hidutilities.c
+++ b/Src/Inputs/Macosx_hidutilities.c
@@ -1579,7 +1579,7 @@ static void macosx_hidutilities_quit(void)
 } /* macosx_hidutilities_quit */
 
 
-static int macosx_hidutilities_init(void)
+static int macosx_hidutilities_init(const int onlyAbs)
 {
     macosx_hidutilities_quit();  /* just in case... */
 

--- a/Src/Inputs/Manymouse.c
+++ b/Src/Inputs/Manymouse.c
@@ -32,8 +32,8 @@ static const ManyMouseDriver **mice_drivers[] =
 {
     &ManyMouseDriver_hidmanager,
     &ManyMouseDriver_hidutilities,
-    &ManyMouseDriver_xinput2,
-    &ManyMouseDriver_evdev
+    &ManyMouseDriver_evdev,
+    &ManyMouseDriver_xinput2
 };
 
 
@@ -52,18 +52,19 @@ int ManyMouse_Init(const int onlyAbs)
     if (driver != NULL)
         return -1;
 
-    for (i = 0; (i < upper) && (driver == NULL); i++)
+    for (i = 0; i < upper; i++)
     {
         const ManyMouseDriver *this_driver = *(mice_drivers[i]);
         if (this_driver != NULL) /* if not built for this platform, skip it. */
         {
             const int mice = this_driver->init(onlyAbs);
-            if (mice > retval) {
+            if (mice > retval)
                 retval = mice; /* may move from "error" to "no mice found". */
-	    }
 
-            if (mice >= 0)
+            if (mice > 0) {
                 driver = this_driver;
+                break; /* exit early since we've got our driver of choice */
+            }
         } /* if */
     } /* for */
 

--- a/Src/Inputs/Manymouse.c
+++ b/Src/Inputs/Manymouse.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include "Manymouse.h"
 
 static const char *manymouse_copyright =
@@ -67,6 +68,8 @@ int ManyMouse_Init(const int onlyAbs)
             }
         } /* if */
     } /* for */
+
+    printf("Initialized ManyMouse using %s backend\n", driver == NULL ? "no" : ManyMouse_DriverName());
 
     return retval;
 } /* ManyMouse_Init */

--- a/Src/Inputs/Manymouse.c
+++ b/Src/Inputs/Manymouse.c
@@ -53,7 +53,7 @@ int ManyMouse_Init(const int onlyAbs)
     if (driver != NULL)
         return -1;
 
-    for (i = 0; i < upper; i++)
+    for (i = 0; i < upper && driver == NULL; i++)
     {
         const ManyMouseDriver *this_driver = *(mice_drivers[i]);
         if (this_driver != NULL) /* if not built for this platform, skip it. */
@@ -64,7 +64,10 @@ int ManyMouse_Init(const int onlyAbs)
 
             if (mice > 0) {
                 driver = this_driver;
-                break; /* exit early since we've got our driver of choice */
+            } else {
+                this_driver->quit();
+                this_driver = NULL;
+                retval = -1;
             }
         } /* if */
     } /* for */

--- a/Src/Inputs/Manymouse.c
+++ b/Src/Inputs/Manymouse.c
@@ -39,7 +39,7 @@ static const ManyMouseDriver **mice_drivers[] =
 
 static const ManyMouseDriver *driver = NULL;
 
-int ManyMouse_Init(void)
+int ManyMouse_Init(const int onlyAbs)
 {
     const int upper = (sizeof (mice_drivers) / sizeof (mice_drivers[0]));
     int i;
@@ -57,7 +57,7 @@ int ManyMouse_Init(void)
         const ManyMouseDriver *this_driver = *(mice_drivers[i]);
         if (this_driver != NULL) /* if not built for this platform, skip it. */
         {
-            const int mice = this_driver->init();
+            const int mice = this_driver->init(onlyAbs);
             if (mice > retval) {
                 retval = mice; /* may move from "error" to "no mice found". */
 	    }

--- a/Src/Inputs/Manymouse.h
+++ b/Src/Inputs/Manymouse.h
@@ -40,14 +40,14 @@ typedef struct
 typedef struct
 {
     const char *driver_name;
-    int (*init)(void);
+    int (*init)(const int);
     void (*quit)(void);
     const char *(*name)(unsigned int index);
     int (*poll)(ManyMouseEvent *event);
 } ManyMouseDriver;
 
 
-int ManyMouse_Init(void);
+int ManyMouse_Init(const int);
 const char *ManyMouse_DriverName(void);
 void ManyMouse_Quit(void);
 const char *ManyMouse_DeviceName(unsigned int index);

--- a/Src/Inputs/X11_xinput2.c
+++ b/Src/Inputs/X11_xinput2.c
@@ -63,6 +63,9 @@ static ManyMouseEvent input_events[MAX_EVENTS];
 static volatile int input_events_read = 0;
 static volatile int input_events_write = 0;
 
+// Currently a dummy stub
+static unsigned int absOnly = 0;
+
 static void queue_event(const ManyMouseEvent *event)
 {
     /* copy the event info. We'll process it in ManyMouse_PollEvent(). */
@@ -321,8 +324,9 @@ static int x11_xinput2_init_internal(void)
 } /* x11_xinput2_init_internal */
 
 
-static int x11_xinput2_init(void)
+static int x11_xinput2_init(const int onlyAbs)
 {
+    absOnly = onlyAbs;
     int retval = x11_xinput2_init_internal();
     if (retval < 0)
         xinput2_cleanup();

--- a/Src/Inputs/X11_xinput2.c
+++ b/Src/Inputs/X11_xinput2.c
@@ -284,9 +284,6 @@ static int x11_xinput2_init_internal(void)
 
     xinput2_cleanup();  /* just in case... */
 
-    if (getenv("MANYMOUSE_NO_XINPUT2") != NULL)
-        return -1;
-
     if (!find_api_symbols())
         return -1;  /* couldn't find all needed symbols. */
 

--- a/Src/OSD/DefaultConfigFile.h
+++ b/Src/OSD/DefaultConfigFile.h
@@ -94,6 +94,13 @@
     "PortOut = 1971\n"
     "AddressOut = \"127.0.0.1\"\n"
     "\n"
+#ifdef SUPERMODEL_MANYMOUSE
+    "; Input\n"
+    "; Sets the ManyMouse backend to ignore any mouse devices that don't provide\n"
+    "; absolute positioning when enabled, ideal for using Lightguns.\n"
+    "ABSMiceOnly = false\n"
+    "\n"
+#endif
     "; Common\n"
     "InputUIExit = \"JOY1_BUTTON10+JOY1_BUTTON9\"\n"
     "InputStart1 = \"KEY_1,JOY1_BUTTON9\"\n"

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1693,7 +1693,7 @@ static void Help(void)
   printf("  -outputs=<s>            Outputs [Default: %s]\n", defaultConfig["Outputs"].ValueAs<std::string>().c_str());
 #endif
 #ifdef SUPERMODEL_MANYMOUSE
-  puts("  -lightguns-only         Filter non-Absolute Positional Mouse Devices");
+  puts("  -abs-mice-only          Filter non-Absolute Positional Mouse Devices");
 #endif
   puts("  -print-inputs           Prints current input configuration");
   puts("");
@@ -1811,7 +1811,7 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
     { "-no-force-feedback",   { "ForceFeedback",    false } },
     { "-force-feedback",      { "ForceFeedback",    true } },
 #ifdef SUPERMODEL_MANYMOUSE
-    { "-lightguns-only",      { "ABSMiceOnly",      true }},
+    { "-abs-mice-only",      { "ABSMiceOnly",      true }},
 #endif
     { "-dump-textures",       { "DumpTextures",     true } },
   };

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1584,6 +1584,9 @@ static Util::Config::Node DefaultConfig()
 #endif
 #else
   config.Set("InputSystem", "sdl");
+#ifdef SUPERMODEL_MANYMOUSE
+  config.Set("ABSMiceOnly", true);
+#endif
   // SDL ForceFeedback
   config.Set("SDLConstForceMax", "100");
   config.Set("SDLSelfCenterMax", "100");
@@ -1808,7 +1811,7 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
     { "-no-force-feedback",   { "ForceFeedback",    false } },
     { "-force-feedback",      { "ForceFeedback",    true } },
 #ifdef SUPERMODEL_MANYMOUSE
-    { "-lightguns-only",      { "ABSMiceFilter",    true }},
+    { "-lightguns-only",      { "ABSMiceOnly",      true }},
 #endif
     { "-dump-textures",       { "DumpTextures",     true } },
   };
@@ -1985,7 +1988,7 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
         cmd_line.print_inputs = true;
 #ifdef SUPERMODEL_MANYMOUSE
       else if (arg == "-lightguns-only")
-        cmd_line.config.Set("ABSMiceFilter", true);
+        cmd_line.config.Set("ABSMiceOnly", true);
 #endif
 #ifdef SUPERMODEL_DEBUGGER
       else if (arg == "-disable-debugger")

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1585,7 +1585,7 @@ static Util::Config::Node DefaultConfig()
 #else
   config.Set("InputSystem", "sdl");
 #ifdef SUPERMODEL_MANYMOUSE
-  config.Set("ABSMiceOnly", true);
+  config.Set("ABSMiceOnly", false);
 #endif
   // SDL ForceFeedback
   config.Set("SDLConstForceMax", "100");

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1689,6 +1689,9 @@ static void Help(void)
   printf("  -input-system=<s>       Input system [Default: %s]\n", defaultConfig["InputSystem"].ValueAs<std::string>().c_str());
   printf("  -outputs=<s>            Outputs [Default: %s]\n", defaultConfig["Outputs"].ValueAs<std::string>().c_str());
 #endif
+#ifdef SUPERMODEL_MANYMOUSE
+  puts("  -lightguns-only         Filter non-Absolute Positional Mouse Devices");
+#endif
   puts("  -print-inputs           Prints current input configuration");
   puts("");
   puts("Debug Options:");
@@ -1804,6 +1807,9 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
 #endif
     { "-no-force-feedback",   { "ForceFeedback",    false } },
     { "-force-feedback",      { "ForceFeedback",    true } },
+#ifdef SUPERMODEL_MANYMOUSE
+    { "-lightguns-only",      { "ABSMiceFilter",    true }},
+#endif
     { "-dump-textures",       { "DumpTextures",     true } },
   };
   for (int i = 1; i < argc; i++)
@@ -1977,6 +1983,10 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
         cmd_line.config_inputs = true;
       else if (arg == "-print-inputs")
         cmd_line.print_inputs = true;
+#ifdef SUPERMODEL_MANYMOUSE
+      else if (arg == "-lightguns-only")
+        cmd_line.config.Set("ABSMiceFilter", true);
+#endif
 #ifdef SUPERMODEL_DEBUGGER
       else if (arg == "-disable-debugger")
         cmd_line.disable_debugger = true;

--- a/Src/OSD/SDL/SDLInputSystem.cpp
+++ b/Src/OSD/SDL/SDLInputSystem.cpp
@@ -483,7 +483,7 @@ bool CSDLInputSystem::InitializeSystem()
 
 #ifdef SUPERMODEL_MANYMOUSE
   // Initiate ManyMouse
-  available_mice = ManyMouse_Init();
+  available_mice = ManyMouse_Init(m_config["ABSMiceFilter"].ValueAs<bool>());
   static MouseDetails mice[MAX_MICE];
 
   std::cout << std::endl;

--- a/Src/OSD/SDL/SDLInputSystem.cpp
+++ b/Src/OSD/SDL/SDLInputSystem.cpp
@@ -483,7 +483,7 @@ bool CSDLInputSystem::InitializeSystem()
 
 #ifdef SUPERMODEL_MANYMOUSE
   // Initiate ManyMouse
-  available_mice = ManyMouse_Init(m_config["ABSMiceFilter"].ValueAs<bool>());
+  available_mice = ManyMouse_Init(m_config["ABSMiceOnly"].ValueAs<bool>());
   static MouseDetails mice[MAX_MICE];
 
   std::cout << std::endl;


### PR DESCRIPTION
Evdev backend will now sort devices from lowest/first event ID to highest/last, skip over non-event files, and will avoid erroneously adding gamepads as mice.

If ~~`SUPERMODEL_GUNSONLY`~~ `-lightguns-only` is set from CLI, or `ABSMiceFilter = true` in `Config/Supermodel.ini`, evdev backend will filter out any devices that don't `has_absolutes`, so only lightgun devices will be listed.

As a sidenote, FWIW, the preferred `Xinput2` backend does **not** work well with Wayland, as it will only show the same four devices, even when there's more or less plugged in:
```
// Running through Gamescope/Wayland Desktop, XInput2 default backend
#1: xwayland-pointer:19
#2: xwayland-relative-pointer:19
#3: xwayland-pointer-gestures:19
#4: xwayland-touch:19

// Running in native Plasma X11, XInput2 default backend
#1: Logitech G502 HERO Gaming Mouse
#2: Logitech G502 HERO Gaming Mouse Keyboard
#3: Keychron Keychron C2
#4: OpenFIRE OF Stunner Mouse
#5: OpenFIRE FIRE-PiCON Mouse

// Running in either native Plasma X11 or Gamescope, MANYMOUSE_NO_XINPUT2=1
#1: Logitech G502 HERO Gaming Mouse
#2: OpenFIRE OF Stunner Mouse
#3: OpenFIRE FIRE-PiCON Mouse

// Running in either native Plasma X11 or Gamescope, MANYMOUSE_NO_XINPUT=1 & -lightguns-only
#1: OpenFIRE OF Stunner Mouse
#2: OpenFIRE FIRE-PiCON Mouse
```

I'm not sure if maybe we might want to make EVDEV a default for the upcoming Wayland-only desktops and/or more consistent detection on other platforms? ~~And an envvar is a quick'n'dirty solution, but should this be toggleable from a CLI switch/setting?~~